### PR TITLE
fix: ambiguous `use daml::prelude::*` in codegen, prefix with `::`

### DIFF
--- a/daml_codegen/src/generator/separate.rs
+++ b/daml_codegen/src/generator/separate.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::{fs, io};
 
 const DISABLE_WARNINGS: &str = "#![allow(clippy::all, warnings)]";
-const USE_DAML_PRELUDE: &str = "use daml::prelude::*;";
+const USE_DAML_PRELUDE: &str = "use ::daml::prelude::*;";
 
 pub fn generate_archive_separate(
     archive: &DamlArchive<'_>,

--- a/daml_codegen/src/renderer/module_renderer.rs
+++ b/daml_codegen/src/renderer/module_renderer.rs
@@ -32,7 +32,7 @@ pub fn quote_module_tree(
         let module_name_tokens = quote_escaped_ident(name.to_snake_case());
         quote!(
             pub mod #module_name_tokens {
-                use daml::prelude::*;
+                use ::daml::prelude::*;
                 #module_tokens
                 #( #all_children )*
             }


### PR DESCRIPTION
Closes #68 