### PR TITLE
fix(test): incorrectly specified and redundant `tokio` versions

### DIFF
--- a/daml_bridge/Cargo.toml
+++ b/daml_bridge/Cargo.toml
@@ -30,7 +30,6 @@ humantime = "2.1.0"
 
 [dev-dependencies]
 daml = { path = "../daml", features = ["json", "macros", "util", "sandbox", "grpc"] }
-tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread", "time"] }
 anyhow = "1.0.55"
 lazy_static = "1.4.0"
 parking_lot = "0.12.0"

--- a/daml_json/Cargo.toml
+++ b/daml_json/Cargo.toml
@@ -26,7 +26,7 @@ tracing = "0.1.31"
 
 [dev-dependencies]
 daml = { path = "../daml", features = [ "macros", "util" ,"sandbox", "grpc" ] }
-tokio = { version = "1", features = [ "macros", "rt-multi-thread" ] }
+tokio = { version = "1.17.0", features = [ "macros", "rt-multi-thread" ] }
 maplit = "1.0.2"
 anyhow = "1.0.55"
 lazy_static = "1.4.0"

--- a/daml_util/Cargo.toml
+++ b/daml_util/Cargo.toml
@@ -26,4 +26,4 @@ itertools = "0.10.3"
 uuid = "0.8.2"
 
 [dev-dependencies]
-tokio = { version = "1", features = [ "macros", "rt-multi-thread" ] }
+tokio = { version = "1.17.0", features = [ "macros", "rt-multi-thread" ] }


### PR DESCRIPTION
Closes #82 